### PR TITLE
Make relative imports more compact

### DIFF
--- a/src/python_minifier/module_printer.py
+++ b/src/python_minifier/module_printer.py
@@ -265,13 +265,13 @@ class ModulePrinter(ExpressionPrinter):
     def visit_ImportFrom(self, node):
         assert isinstance(node, ast.ImportFrom)
 
-        if node.module is None:
-            self.code += 'from ' + ('.' * node.level) + ' '
-        else:
-            self.code += 'from ' + ('.' * node.level)
-            self.code += node.module
+        self.code += 'from' + ('.' * node.level)
+        if node.module is not None:
+            if node.level == 0:
+                self.code += ' '
+            self.code += node.module + ' '
 
-        self.code += ' import '
+        self.code += 'import '
         first = True
         for n in node.names:
             if first:


### PR DESCRIPTION
Currently, minifying `from . import test` adds an extra space:

```py
from .  import test
from .b import test
```

This PR removes whitespace around the `.`:

```py
from.import test
from.b import test
```