### PR TITLE
Improve renaming decisions

### DIFF
--- a/src/python_minifier/rename/bind_names.py
+++ b/src/python_minifier/rename/bind_names.py
@@ -54,9 +54,7 @@ class NameBinder(NodeVisitor):
             if arg_rename_in_place(node):
                 binding.add_reference(node)
             else:
-                binding.add_reference(
-                    node, reserved=node.id, rename_cost=(len(node.id) * 2) + 2
-                )  # Assuming that the new name is only a single character
+                binding.add_reference(node, reserved=node.id)
 
                 if isinstance(node.namespace, ast.Lambda):
                     # Lambda function arguments can't be renamed without breaking keyword arguments
@@ -88,7 +86,7 @@ class NameBinder(NodeVisitor):
             # This binds the root module only for a dotted import
 
             binding = self.get_binding(root_module, node.namespace)
-            binding.add_reference(node, rename_cost=len(node.name) + 4)
+            binding.add_reference(node)
 
             if '.' in node.name:
                 binding.disallow_rename()
@@ -110,9 +108,7 @@ class NameBinder(NodeVisitor):
         if arg_rename_in_place(node):
             binding.add_reference(node)
         else:
-            binding.add_reference(
-                node, reserved=node.arg, rename_cost=(len(node.arg) * 2) + 2
-            )  # Assuming that the new name is only a single character
+            binding.add_reference(node, reserved=node.arg)
 
             if isinstance(node.namespace, ast.Lambda):
                 # Lambda function arguments can't be renamed without breaking keyword arguments

--- a/src/python_minifier/rename/bind_names.py
+++ b/src/python_minifier/rename/bind_names.py
@@ -45,7 +45,7 @@ class NameBinder(NodeVisitor):
         return binding
 
     def visit_Name(self, node):
-        if isinstance(node.ctx, ast.Store) or isinstance(node.ctx, ast.Del):
+        if isinstance(node.ctx, (ast.Store, ast.Del)):
             self.get_binding(node.id, node.namespace).add_reference(node)
 
         if isinstance(node.ctx, ast.Param):

--- a/src/python_minifier/rename/binding.py
+++ b/src/python_minifier/rename/binding.py
@@ -119,7 +119,7 @@ class Binding(object):
                     pass
                 if node.kwarg == self._name:
                     pass
-            elif isinstance(node, ast.arg):
+            elif is_ast_node(node, 'arg'):
                 if not arg_rename_in_place(node):
                     arg_rename = True
             else:
@@ -152,10 +152,10 @@ class Binding(object):
             elif is_ast_node(node, (ast.Global, 'Nonlocal')):
                 pass
             elif isinstance(node, ast.alias):
-                pass
+                mentions += 1
             elif isinstance(node, ast.arguments):
                 pass
-            elif isinstance(node, ast.arg):
+            elif is_ast_node(node, 'arg'):
                 if not arg_rename_in_place(node):
                     mentions += 1
                     arg_rename = True
@@ -192,7 +192,7 @@ class Binding(object):
                     mentions += 1
                 if node.kwarg == self._name:
                     mentions += 1
-            elif isinstance(node, ast.arg):
+            elif is_ast_node(node, 'arg'):
                 arg_rename = True
             else:
                 raise AssertionError('Unknown reference node')

--- a/src/python_minifier/rename/binding.py
+++ b/src/python_minifier/rename/binding.py
@@ -113,7 +113,8 @@ class Binding(object):
             elif is_ast_node(node, (ast.Global, 'Nonlocal')):
                 pass
             elif isinstance(node, ast.alias):
-                additional_bytes += 4  # ' as '
+                if node.asname is None:
+                    additional_bytes += 4  # ' as '
             elif isinstance(node, ast.arguments):
                 if node.vararg == self._name:
                     pass

--- a/src/python_minifier/rename/binding.py
+++ b/src/python_minifier/rename/binding.py
@@ -152,7 +152,9 @@ class Binding(object):
             elif is_ast_node(node, (ast.Global, 'Nonlocal')):
                 pass
             elif isinstance(node, ast.alias):
-                mentions += 1
+                if node.asname is None:
+                    # import foo -> import foo as bar
+                    mentions += 1
             elif isinstance(node, ast.arguments):
                 pass
             elif is_ast_node(node, 'arg'):
@@ -273,7 +275,11 @@ class NameBinding(Binding):
         """
 
         current_cost = len(self.references) * len(self._name)
-        rename_cost = (self.old_mention_count() * len(self._name)) + ((self.new_mention_count()) * len(new_name)) + self.additional_byte_cost()
+
+        old_mentions = self.old_mention_count()
+        new_mentions = self.new_mention_count()
+        additional_bytes = self.additional_byte_cost()
+        rename_cost = (old_mentions * len(self._name)) + (new_mentions * len(new_name)) + additional_bytes
 
         return rename_cost <= current_cost
 

--- a/src/python_minifier/rename/binding.py
+++ b/src/python_minifier/rename/binding.py
@@ -110,7 +110,7 @@ class Binding(object):
                 mentions += 1
             elif isinstance(node, ast.ExceptHandler):
                 mentions += 1
-            elif isinstance(node, (ast.Global, ast.Nonlocal)):
+            elif is_ast_node(node, (ast.Global, 'Nonlocal')):
                 mentions += len([n for n in node.names if n == self._name])
             elif isinstance(node, ast.alias):
                 mentions += 1

--- a/src/python_minifier/rename/binding.py
+++ b/src/python_minifier/rename/binding.py
@@ -91,7 +91,7 @@ class Binding(object):
         """
         return len(self._references)
 
-    def num_new_mentions(self):
+    def new_mention_count(self):
         """
         The number of times a new name would be mentioned in the source code
         """
@@ -312,7 +312,7 @@ class BuiltinBinding(NameBinding):
             # Classes must inherit from object to become a new-style class in python2
             self.disallow_rename()
 
-    def num_new_mentions(self):
+    def new_mention_count(self):
         # All mentions must be Names, which would be replaced
         # Plus an Assign with the new name
         return len(self.references) + 1

--- a/src/python_minifier/rename/rename_literals.py
+++ b/src/python_minifier/rename/rename_literals.py
@@ -80,7 +80,7 @@ class HoistedBinding(Binding):
 
     def should_rename(self, new_name):
         current_cost = len(self.references) * len(repr(self.value))
-        rename_cost = (self.old_mention_count() * len(self._name)) + ((self.new_mention_count()) * len(new_name)) + self.additional_byte_cost()
+        rename_cost = (self.old_mention_count() * len(repr(self.value))) + ((self.new_mention_count()) * len(new_name)) + self.additional_byte_cost()
 
         return rename_cost <= current_cost
 

--- a/src/python_minifier/rename/rename_literals.py
+++ b/src/python_minifier/rename/rename_literals.py
@@ -51,6 +51,11 @@ class HoistedBinding(Binding):
     def __repr__(self):
         return self.__class__.__name__ + '(value=%r)' % self.value
 
+    def num_new_mentions(self):
+        # All mentions must be literals, which would be replaced
+        # Plus an Assign with the new name
+        return len(self.references) + 1
+
     def rename(self, new_name):
 
         for node in self.references:

--- a/src/python_minifier/rename/rename_literals.py
+++ b/src/python_minifier/rename/rename_literals.py
@@ -51,7 +51,7 @@ class HoistedBinding(Binding):
     def __repr__(self):
         return self.__class__.__name__ + '(value=%r)' % self.value
 
-    def num_new_mentions(self):
+    def new_mention_count(self):
         # All mentions must be literals, which would be replaced
         # Plus an Assign with the new name
         return len(self.references) + 1

--- a/src/python_minifier/rename/renamer.py
+++ b/src/python_minifier/rename/renamer.py
@@ -36,7 +36,7 @@ def sorted_bindings(module):
 
     def comp(tup):
         namespace, binding = tup
-        return binding.num_new_mentions()
+        return binding.new_mention_count()
 
     return sorted(all_bindings(module), key=comp, reverse=True)
 

--- a/src/python_minifier/rename/renamer.py
+++ b/src/python_minifier/rename/renamer.py
@@ -36,7 +36,7 @@ def sorted_bindings(module):
 
     def comp(tup):
         namespace, binding = tup
-        return len(binding.references)
+        return binding.num_new_mentions()
 
     return sorted(all_bindings(module), key=comp, reverse=True)
 

--- a/src/python_minifier/rename/resolve_names.py
+++ b/src/python_minifier/rename/resolve_names.py
@@ -24,7 +24,7 @@ def get_binding(name, namespace):
             if name in ['exec', 'eval', 'locals', 'globals', 'vars']:
                 namespace.tainted = True
 
-            binding = BuiltinBinding(name, namespace, rename_cost=len(name) + 1)
+            binding = BuiltinBinding(name, namespace)
             namespace.bindings.append(binding)
             return binding
 

--- a/test/test_rename_locals.py
+++ b/test/test_rename_locals.py
@@ -310,3 +310,17 @@ def f(*A,**B):pass
     expected_ast = ast.parse(expected)
     actual_ast = rename_locals(source)
     assert_code(expected_ast, actual_ast)
+
+def test_multiple_args():
+    source = '''
+def f(hello, hello):
+    print(hello + hello)      
+    '''
+    expected = '''
+def f(hello, hello):
+    A=hello
+    print(A + A)
+    '''
+    expected_ast = ast.parse(expected)
+    actual_ast = rename_locals(source)
+    assert_code(expected_ast, actual_ast)


### PR DESCRIPTION
Evaluate potential renames in descending order of mentions of the new name.
Use better accounting for the size difference of renames.