### PR TITLE
Add recursive minification functionality

### DIFF
--- a/src/python_minifier/__init__.py
+++ b/src/python_minifier/__init__.py
@@ -5,6 +5,8 @@ a 'minified' representation of the same source code.
 """
 
 import ast
+import os
+import shutil
 
 from python_minifier.ast_compare import CompareError, compare_ast
 from python_minifier.module_printer import ModulePrinter
@@ -23,6 +25,7 @@ from python_minifier.transforms.remove_literal_statements import RemoveLiteralSt
 from python_minifier.transforms.remove_object_base import RemoveObject
 from python_minifier.transforms.remove_pass import RemovePass
 from python_minifier.transforms.remove_posargs import remove_posargs
+from python_minifier.util import ignore_dir, ignore_file
 
 
 class UnstableMinification(RuntimeError):
@@ -88,48 +91,217 @@ def minify(
     :rtype: str
 
     """
+    minifier = Minifier(
+        remove_annotations,
+        remove_pass,
+        remove_literal_statements,
+        combine_imports,
+        hoist_literals,
+        rename_locals,
+        preserve_locals,
+        rename_globals,
+        preserve_globals,
+        remove_object_base,
+        convert_posargs_to_args,
+    )
+    return minifier.minify(source, filename)
 
-    filename = filename or 'python_minifier.minify source'
 
-    # This will raise if the source file can't be parsed
-    module = ast.parse(source, filename)
+class Minifier(object):
+    def __init__(
+        self,
+        remove_annotations=True,
+        remove_pass=True,
+        remove_literal_statements=False,
+        combine_imports=True,
+        hoist_literals=True,
+        rename_locals=True,
+        preserve_locals=None,
+        rename_globals=False,
+        preserve_globals=None,
+        remove_object_base=True,
+        convert_posargs_to_args=True,
+    ):
+        """Class for minifying python modules.
 
-    add_namespace(module)
+        The module is transformed according the the arguments.
+        If all transformation arguments are False, no transformations are made to the AST, the returned string will
+        parse into exactly the same module.
 
-    if remove_literal_statements:
-        module = RemoveLiteralStatements()(module)
+        Using the default arguments only transformations that are always or almost always safe are enabled.
 
-    if combine_imports:
-        module = CombineImports()(module)
+        :param bool remove_annotations: If type annotations should be removed where possible
+        :param bool remove_pass: If Pass statements should be removed where possible
+        :param bool remove_literal_statements: If statements consisting of a single literal should be removed, including docstrings
+        :param bool combine_imports: Combine adjacent import statements where possible
+        :param bool hoist_literals: If str and byte literals may be hoisted to the module level where possible.
+        :param bool rename_locals: If local names may be shortened
+        :param preserve_locals: Locals names to leave unchanged when rename_locals is True
+        :type preserve_locals: list[str]
+        :param bool rename_globals: If global names may be shortened
+        :param preserve_globals: Global names to leave unchanged when rename_globals is True
+        :type preserve_globals: list[str]
+        :param bool remove_object_base: If object as a base class may be removed
+        :param bool convert_posargs_to_args: If positional-only arguments will be converted to normal arguments
 
-    if remove_annotations:
-        module = RemoveAnnotations()(module)
+        """
+        self.remove_annotations = remove_annotations
+        self.remove_pass = remove_pass
+        self.remove_literal_statements = remove_literal_statements
+        self.combine_imports = combine_imports
+        self.hoist_literals = hoist_literals
+        self.rename_locals = rename_locals
+        self.preserve_locals = preserve_locals
+        self.rename_globals = rename_globals
+        self.preserve_globals = preserve_globals
+        self.remove_object_base = remove_object_base
+        self.convert_posargs_to_args = convert_posargs_to_args
 
-    if remove_pass:
-        module = RemovePass()(module)
+    def minify(self, source, filename=None):
+        """Minify a python module.
 
-    if remove_object_base:
-        module = RemoveObject()(module)
+        :param bytes source: The python module source code. If a str, will be encoded to bytes.
+        :param str filename: The original source filename if known
 
-    bind_names(module)
-    resolve_names(module)
+        :rtype: str
+        """
+        if isinstance(source, str):
+            source.encode()
 
-    if module.tainted:
-        rename_globals = False
-        rename_locals = False
+        filename = filename or 'python_minifier.minify source'
 
-    allow_rename_locals(module, rename_locals, preserve_locals)
-    allow_rename_globals(module, rename_globals, preserve_globals)
+        # This will raise if the source file can't be parsed
+        module = ast.parse(source, filename)
 
-    if hoist_literals:
-        rename_literals(module)
+        add_namespace(module)
 
-    rename(module, prefix_globals=not rename_globals, preserved_globals=preserve_globals)
+        if self.remove_literal_statements:
+            module = RemoveLiteralStatements()(module)
 
-    if convert_posargs_to_args:
-        module = remove_posargs(module)
+        if self.combine_imports:
+            module = CombineImports()(module)
 
-    return unparse(module)
+        if self.remove_annotations:
+            module = RemoveAnnotations()(module)
+
+        if self.remove_pass:
+            module = RemovePass()(module)
+
+        if self.remove_object_base:
+            module = RemoveObject()(module)
+
+        bind_names(module)
+        resolve_names(module)
+
+        if module.tainted:
+            rename_globals = False
+            rename_locals = False
+        else:
+            rename_globals = self.rename_globals
+            rename_locals = self.rename_locals
+
+        allow_rename_locals(module, rename_locals, self.preserve_locals)
+        allow_rename_globals(module, rename_globals, self.preserve_globals)
+
+        if self.hoist_literals:
+            rename_literals(module)
+
+        rename(module, prefix_globals=not rename_globals, preserved_globals=self.preserve_globals)
+
+        if self.convert_posargs_to_args:
+            module = remove_posargs(module)
+
+        return unparse(module)
+
+    def minify_buffer(self, f, filename=None):
+        """Minify a readable buffer.
+
+        :param f: Readable buffer.
+        :param str filename: If known, the name of the file wrapped by the buffer.
+        :rtype: str
+        """
+        return self.minify(f.read(), filename)
+
+    def minify_file(self, path):
+        """Minify the contents of a file.
+
+        :param str path: Path to file.
+        :rtype: str
+        """
+        with open(path, "rb") as f:
+            return self.minify_buffer(f, path)
+
+    def minify_dir(self, in_path, out_path, copy_nonpy=False, force=False):
+        """Recursively minify a directory of python files.
+
+        :param str in_path: Path to directory of existing python files.
+        :param str out_path: Path to directory where minified files will be written.
+        :param bool copy_nonpy: Copy files other than *.py from the in to the out directory.
+            Some file extensions (e.g. cached bytecode) will be ignored.
+            Default False.
+        :param bool force: If the out_dir is not empty, delete it.
+            Ignored if in_dir == out_dir.
+            Default False.
+        """
+        in_path = os.path.abspath(in_path)
+        out_path = os.path.abspath(out_path)
+
+        if in_path == out_path:
+            copy_nonpy = False
+        else:
+            if os.path.exists(out_path) and os.listdir(out_path):
+                if force:
+                    shutil.rmtree(out_path)
+                else:
+                    raise FileExistsError('Non-empty target directory already exists')
+
+        def truncate(p):
+            return p[len(in_path):].lstrip(os.sep)
+
+        py_paths = []
+        nonpy_paths = []
+        dirs = {out_path}
+
+        for root, dpaths, fpaths in os.walk(in_path):
+            rel_root = truncate(root)
+            has_files = False
+
+            for fpath in fpaths:
+                rel_fpath = os.path.join(rel_root, fpath)
+                if fpath.endswith('.py'):
+                    py_paths.append(rel_fpath)
+                    has_files = True
+                elif copy_nonpy and not ignore_file(fpath):
+                    nonpy_paths.append(rel_fpath)
+                    has_files = True
+
+            if has_files:
+                dirs.add(rel_root)
+
+            to_ignore = []
+
+            for idx, dpath in enumerate(dpaths):
+                if ignore_dir(dpath):
+                    to_ignore.append(idx)
+
+            for idx in reversed(to_ignore):
+                dpaths.pop(idx)
+
+        print(dirs)
+        for dpath in dirs:
+            os.makedirs(os.path.join(out_path, dpath), exist_ok=True)
+            print(os.path.join(out_path, dpath))
+
+        for path in py_paths:
+            s = self.minify_file(os.path.join(in_path, path))
+            with open(os.path.join(out_path, path), "w") as f:
+                f.write(s)
+
+        for path in nonpy_paths:
+            shutil.copyfile(
+                os.path.join(in_path, path),
+                os.path.join(out_path, path),
+            )
 
 
 def unparse(module):

--- a/src/python_minifier/__main__.py
+++ b/src/python_minifier/__main__.py
@@ -1,11 +1,14 @@
 from __future__ import print_function
 
 import sys
+import os
+from contextlib import contextmanager
+import logging
 
 import argparse
 from pkg_resources import get_distribution, DistributionNotFound
 
-from python_minifier import minify
+from python_minifier import Minifier
 
 try:
     version = get_distribution('python_minifier').version
@@ -13,11 +16,34 @@ except DistributionNotFound:
     version = '0.0.0'
 
 
+logger = logging.getLogger(__name__)
+
+
+def dash_none(s):
+    if s == '-':
+        return None
+    return s
+
+
+@contextmanager
+def open_buffer(path=None, mode='r'):
+    if mode not in ("r", "w"):
+        raise ValueError("Unknown mode '{}', must be 'r' or 'w'".format(mode))
+    if path is None:
+        if mode == 'r':
+            yield sys.stdin
+        else:
+            yield sys.stdout
+    else:
+        with open(path, mode) as f:
+            yield f
+
+
 def main():
 
     parser = argparse.ArgumentParser(prog='pyminify', description='Minify Python source')
 
-    parser.add_argument('path', type=str, help='The source file to minify. Use "-" to read from stdin')
+    parser.add_argument('path', type=dash_none, help='The source file to minify. Use "-" to read from stdin')
 
     parser.add_argument(
         '--no-combine-imports',
@@ -82,16 +108,41 @@ def main():
         help='Disable converting positional only arguments to normal arguments',
         dest='convert_posargs_to_args',
     )
+    parser.add_argument(
+        '--output',
+        '-o',
+        type=dash_none,
+        help=(
+            'Path to output file (if input is a file path or -), '
+            'or directory (if input is a directory, '
+            'in which case this argument is mandatory), or stdout if "-" (default).'
+        ),
+    )
+    parser.add_argument(
+        '--in-place',
+        '-i',
+        action='store_true',
+        help='Replace file contents rather than writing to stdout.'
+    )
+    parser.add_argument(
+        '--rec-copy-nonpy',
+        '-n',
+        action='store_true',
+        help='If input is a directory, also copy non-"*.py" files into output directory.',
+    )
+    parser.add_argument(
+        '--rec-delete-contents',
+        '-d',
+        action='store_true',
+        help=(
+            'If output is a non-empty directory, delete its contents. '
+            'Ignored if input and output are the same.'
+        ),
+    )
 
     parser.add_argument('-v', '--version', action='version', version=version)
 
     args = parser.parse_args()
-
-    if args.path == '-':
-        source = sys.stdin.read()
-    else:
-        with open(args.path, 'rb') as f:
-            source = f.read()
 
     preserve_globals = []
     if args.preserve_globals:
@@ -105,23 +156,40 @@ def main():
             names = [name.strip() for name in arg.split(',') if name]
             preserve_locals.extend(names)
 
-    sys.stdout.write(
-        minify(
-            source,
-            filename=args.path,
-            combine_imports=args.combine_imports,
-            remove_pass=args.remove_pass,
-            remove_annotations=args.remove_annotations,
-            remove_literal_statements=args.remove_literal_statements,
-            hoist_literals=args.hoist_literals,
-            rename_locals=args.rename_locals,
-            preserve_locals=preserve_locals,
-            rename_globals=args.rename_globals,
-            preserve_globals=preserve_globals,
-            remove_object_base=args.remove_object_base,
-            convert_posargs_to_args=args.convert_posargs_to_args,
-        )
+    minifier = Minifier(
+        combine_imports=args.combine_imports,
+        remove_pass=args.remove_pass,
+        remove_annotations=args.remove_annotations,
+        remove_literal_statements=args.remove_literal_statements,
+        hoist_literals=args.hoist_literals,
+        rename_locals=args.rename_locals,
+        preserve_locals=preserve_locals,
+        rename_globals=args.rename_globals,
+        preserve_globals=preserve_globals,
+        remove_object_base=args.remove_object_base,
+        convert_posargs_to_args=args.convert_posargs_to_args,
     )
+
+    if args.in_place:
+        if args.output is not None:
+            logger.warning('--in-place given; --output will be ignored')
+        args.output = args.path
+
+    if args.path and os.path.isdir(args.path):
+        if args.output is None:
+            raise ValueError('Input is a directory, but no --output directory given')
+        minifier.minify_dir(
+            os.path.abspath(args.path),
+            os.path.abspath(args.output),
+            args.rec_copy_nonpy,
+            args.rec_delete_contents,
+        )
+    else:
+        with open_buffer(args.path) as in_f:
+            target = minifier.minify_buffer(in_f, args.path)
+
+        with open_buffer(args.output) as out_f:
+            out_f.write(target)
 
 
 if __name__ == '__main__':

--- a/src/python_minifier/util.py
+++ b/src/python_minifier/util.py
@@ -1,4 +1,6 @@
 import ast
+import os
+
 
 def is_ast_node(node, types):
     """
@@ -45,4 +47,27 @@ def is_ast_node(node, types):
         else:
             raise RuntimeError('Unknown Constant value %r' % type(node.value))
 
+    return False
+
+
+def ignore_file(path):
+    """Whether to ignore a particular file for copying when minifying a directory.
+
+    :param str path: File path.
+    :rtype: bool
+    """
+    _, ext = os.path.splitext(path)
+    if ext in ('.pyc', '.pyo', '.pyd', '$py.class'):
+        return True
+    return False
+
+
+def ignore_dir(path):
+    """Whether to ignore a particular directory and its contents when minifying a directory.
+
+    :param str path: Directory path.
+    :rtype: bool
+    """
+    if os.path.basename(path) == "__pycache__":
+        return True
     return False


### PR DESCRIPTION
New methods allow recursively minifying a (nested) directory of python
files.
Optionally, non-'*.py' files are copied across directly.

This is also reflected in the CLI.

Also:

* Refactor into a class so that the same transformation can be applied
  to many strings, and for convenience of other methods
* minify function is now a thin wrapper around that class
* add --in-place argument for writing back to read files and --output argument for specifying file to write to

See #21. Also addresses #40 by making everything read a `str`. I don't know how this will affect usage in py2 but can we just agree to not care about that dead language?

This passes all existing (regular) tests but does not yet introduce any new ones, which it should. But the functionality/ design choices are ready for review.

Open question: I'm in two minds about whether `--in-place` is a good idea, because nobody should ever replace their source code with a minified artefact. Similarly, I'd be happy to always throw an error if you try to write to a non-empty directory, rather than doing some special handling. However, these might be useful for minifying site-packages in-place.
