### PR TITLE
[WIP] Remove parenthesis for single argument exceptions in `raise` statement

### DIFF
--- a/src/python_minifier/module_printer.py
+++ b/src/python_minifier/module_printer.py
@@ -227,7 +227,10 @@ class ModulePrinter(ExpressionPrinter):
 
             if node.exc:
                 self.code += ' '
-                self._expression(node.exc)
+                if isinstance(node.exc, ast.Call) and not node.exc.args:
+                    self._lhs(node.exc.func, node.exc)
+                else:
+                    self._expression(node.exc)
 
             if node.cause:
                 self.code += ' from '


### PR DESCRIPTION
There is no semantic difference between `raise X()` and `raise X`, so for the few instances where you are raising an exception with no arguments you can save 2 bytes. The AST comparison is failing now due to the `Call` node being replaced with a `Name` node, so I don't know what the best way to go about fixing that is. I have tested this on Python 3.5-3.11, but not Python 2.

Also, one suggestion I have would be adding a `--no-ast-verify` flag to allow for forcing output of unstable minifications for debugging purposes, as opposed to using `print(self.code)` or something similar.