### PR TITLE
Fix namespace for new Assign nodes introduced by annotation removal.

### DIFF
--- a/corpus_test/generate_results.py
+++ b/corpus_test/generate_results.py
@@ -115,7 +115,7 @@ def corpus_test(corpus_path, results_path, sha, regenerate_results):
             if entry in result_writer:
                 continue
 
-            logging.debug(entry)
+            logging.debug('Corpus entry [' + entry + ']')
 
             result = minify_corpus_entry(corpus_path, entry)
             result_writer.write(result)

--- a/src/python_minifier/transforms/remove_annotations.py
+++ b/src/python_minifier/transforms/remove_annotations.py
@@ -120,11 +120,11 @@ class RemoveAnnotations(SuiteTransformer):
         if is_dataclass_field(node) or is_typing_sensitive(node):
             return node
         elif node.value:
-            return self.add_child(ast.Assign([node.target], node.value), parent=node.parent)
+            return self.add_child(ast.Assign([node.target], node.value), parent=node.parent, namespace=node.namespace)
         else:
             # Valueless annotations cause the interpreter to treat the variable as a local.
             # I don't know of another way to do that without assigning to it, so
             # keep it as an AnnAssign, but replace the annotation with '0'
 
-            node.annotation = self.add_child(ast.Num(0), parent=node.parent)
+            node.annotation = self.add_child(ast.Num(0), parent=node.parent, namespace=node.namespace)
             return node


### PR DESCRIPTION
This was missed and defaulting to the parent function namespace, which can then mistakenly cause class attributed to be renamed if the parent namespace was the module namespace and renaming globals was enabled.