### PR TITLE
Update github actions versions

### DIFF
--- a/.github/actions/run-in-container/action.yml
+++ b/.github/actions/run-in-container/action.yml
@@ -1,0 +1,125 @@
+name: Run in container
+description: Run a command in a container
+author: Daniel Flook
+
+inputs:
+  image:
+    description: The image to run the command in
+    required: true
+  run:
+    description: The command to run
+    required: true
+  volumes:
+    description: Volumes to mount, one per line. Each line of the form 'source:target'
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Run command
+      env:
+        INPUT_VOLUMES: ${{ inputs.volumes }}
+      run: |
+
+        docker pull --quiet ${{ inputs.image }}
+        
+        function run() {
+          docker run --rm \
+          --workdir /github/workspace \
+          -e "GITHUB_WORKSPACE=/github/workspace" \
+          -v $GITHUB_WORKSPACE:/github/workspace \
+          -e "HOME=/github/home" \
+          -v "$RUNNER_TEMP/_github_home":"/github/home" \
+          -v "/var/run/docker.sock":"/var/run/docker.sock" \
+          --mount type=bind,source="$RUNNER_TEMP/run.sh",target=/run.sh,readonly \
+          -e GITHUB_EVENT_PATH \
+          --mount type=bind,source="$GITHUB_EVENT_PATH",target="$GITHUB_EVENT_PATH,readonly" \
+          -e GITHUB_PATH \
+          --mount type=bind,source="$GITHUB_PATH",target="$GITHUB_PATH" \
+          -e GITHUB_ENV \
+          --mount type=bind,source="$GITHUB_ENV",target="$GITHUB_ENV" \
+          -e GITHUB_STEP_SUMMARY \
+          --mount type=bind,source="$GITHUB_STEP_SUMMARY",target="$GITHUB_STEP_SUMMARY" \
+          -e GITHUB_TOKEN \
+          -e GITHUB_JOB \
+          -e GITHUB_REF \
+          -e GITHUB_SHA \
+          -e GITHUB_REPOSITORY \
+          -e GITHUB_REPOSITORY_OWNER \
+          -e GITHUB_RUN_ID \
+          -e GITHUB_RUN_NUMBER \
+          -e GITHUB_RETENTION_DAYS \
+          -e GITHUB_RUN_ATTEMPT \
+          -e GITHUB_ACTOR \
+          -e GITHUB_WORKFLOW \
+          -e GITHUB_HEAD_REF \
+          -e GITHUB_BASE_REF \
+          -e GITHUB_EVENT_NAME \
+          -e GITHUB_SERVER_URL \
+          -e GITHUB_API_URL \
+          -e GITHUB_GRAPHQL_URL \
+          -e GITHUB_ACTION \
+          -e GITHUB_ACTION_REPOSITORY \
+          -e GITHUB_ACTION_REF \
+          -e RUNNER_DEBUG \
+          -e RUNNER_OS \
+          -e RUNNER_NAME \
+          -e RUNNER_TOOL_CACHE \
+          -e ACTIONS_RUNTIME_URL \
+          -e ACTIONS_RUNTIME_TOKEN \
+          -e ACTIONS_CACHE_URL \
+          -e GITHUB_ACTIONS \
+          -e CI \
+          -e GITHUB_ACTOR_ID \
+          -e GITHUB_OUTPUT \
+          -e GITHUB_REF_NAME \
+          -e GITHUB_REF_PROTECTED \
+          -e GITHUB_REF_TYPE \
+          -e GITHUB_REPOSITORY_ID \
+          -e GITHUB_REPOSITORY_OWNER_ID \
+          -e GITHUB_TRIGGERING_ACTOR \
+          -e GITHUB_WORKFLOW_REF \
+          -e GITHUB_WORKFLOW_SHA \
+          $VOLUMES_ARGS \
+          --entrypoint /bin/bash \
+          ${{ inputs.image }} \
+          --noprofile --norc -eo pipefail /run.sh
+
+        }
+
+        function fix_owners() {
+            cat <<"EOF" >"$RUNNER_TEMP/run.sh"
+            chown -R --reference "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/" || true
+            chown -R --reference "/github/home" "/github/home/" || true
+            chown --reference "$GITHUB_WORKSPACE" $GITHUB_PATH || true
+            chown --reference "$GITHUB_WORKSPACE" $GITHUB_ENV || true
+            chown --reference "$GITHUB_WORKSPACE" $GITHUB_STEP_SUMMARY || true
+        EOF
+            VOLUMES_ARGS=""
+            run
+            rm -f "$RUNNER_TEMP/run.sh"
+        }
+
+        trap fix_owners EXIT
+        
+        VOLUMES_ARGS=""
+        if [[ -n "$INPUT_VOLUMES" ]]; then
+            for mount in $(echo "$INPUT_VOLUMES" | tr ',' '\n'); do
+                VOLUMES_ARGS="$VOLUMES_ARGS -v $mount"
+            done
+        fi
+
+        cat <<"EOF" >"$RUNNER_TEMP/run.sh"
+        ${{ inputs.run }}
+        EOF
+        
+        set -x
+        run
+        set +x
+
+      shell: bash
+
+branding:
+  icon: globe
+  color: purple

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,30 +8,34 @@ concurrency:
   group: release
   cancel-in-progress: false
 
-env:
-   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
 
   release:
+    name: Create sdist and Python 3 Wheel
     runs-on: ubuntu-latest
     container:
       image: danielflook/python-minifier-build:python3.13-2024-09-15
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          fetch-tags: 'true'
+          show-progress: 'false'
 
       - name: Set version statically
         run: |
           VERSION=${{ github.event.release.tag_name }}
           sed -i "s/setup_requires=.*/version='$VERSION',/; s/use_scm_version=.*//" setup.py
+          echo "Version: $VERSION"
 
-      - name: Build package
+      - name: Build distribution packages
         run: |
           pip3 install --upgrade build
           python3 -m build
 
-      - uses: actions/upload-artifact@v3
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
@@ -43,11 +47,13 @@ jobs:
           pip3 install dist/*.tar.gz
           sphinx-build docs/source /tmp/build
 
-      - uses: actions/upload-pages-artifact@v1
+      - name: Upload documentation artifact
+        uses: actions/upload-pages-artifact@v3
         with:
           path: /tmp/build
 
   publish-to-pypi:
+    name: Publish to PyPI
     needs: release
     runs-on: ubuntu-latest
     permissions:
@@ -56,18 +62,20 @@ jobs:
       name: pypi
       url: https://pypi.org/project/python-minifier/${{ github.event.release.tag_name }}
     steps:
-      - uses: actions/download-artifact@v3
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1.10.1
         with:
           print-hash: true
           verbose: true
 
   publish-docs:
+    name: Publish Documentation
     needs: release
     runs-on: ubuntu-latest
     permissions:
@@ -79,4 +87,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release_test.yaml
+++ b/.github/workflows/release_test.yaml
@@ -2,9 +2,6 @@ name: Release Test
 
 on: [push]
 
-env:
-   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
 
   package_python3:
@@ -17,18 +14,20 @@ jobs:
       image: danielflook/python-minifier-build:python3.13-2024-09-15
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          show-progress: false
+          fetch-depth: 1
+          fetch-tags: 'true'
+          show-progress: 'false'
 
       - name: Set version statically
         run: |
           pip3 install setuptools_scm
           VERSION="$(python3 -m setuptools_scm)"
           sed -i "s/setup_requires=.*/version='$VERSION',/; s/use_scm_version=.*//" setup.py
+          echo "Version: $VERSION"
 
-      - name: Create Packages
+      - name: Build distribution packages
         id: package
         run: |
           pip3 install --upgrade build
@@ -37,10 +36,18 @@ jobs:
           echo "sdist=$(find dist -name '*.tar.gz' -printf "%f\n")" >> "$GITHUB_OUTPUT"
           echo "wheel=$(find dist -name '*-py3-*.whl' -printf "%f\n")" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-artifact@v3
+      - name: Upload sdist artifact
+        uses: actions/upload-artifact@v4
         with:
-          name: dist
-          path: dist/
+          name: dist-sdist
+          path: dist/${{ steps.package.outputs.sdist }}
+          if-no-files-found: error
+
+      - name: Upload Python 3 wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-py3-wheel
+          path: dist/${{ steps.package.outputs.wheel }}
           if-no-files-found: error
 
   package_python2:
@@ -52,12 +59,13 @@ jobs:
     container:
       image: danielflook/python-minifier-build:python2.7-2024-09-15
     steps:
-      - uses: actions/download-artifact@v3
+      - name: Download source distribution artifact
+        uses: actions/download-artifact@v4
         with:
-          name: dist
+          name: dist-sdist
           path: dist/
 
-      - name: Build wheel
+      - name: Build Python 2 wheel
         id: package
         run: |
           dnf install -y findutils
@@ -65,10 +73,11 @@ jobs:
           pip wheel dist/${{ needs.package_python3.outputs.sdist }} -w dist
           echo "wheel=$(find dist -name '*-py2-*.whl' -printf "%f\n")" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-artifact@v3
+      - name: Upload Python 2 wheel artifact
+        uses: actions/upload-artifact@v4
         with:
-          name: dist
-          path: dist/
+          name: dist-py2-wheel
+          path: dist/${{ steps.package.outputs.wheel }}
           if-no-files-found: error
 
   documentation:
@@ -78,9 +87,9 @@ jobs:
     container:
       image: danielflook/python-minifier-build:python3.13-2024-09-15
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: dist
+          name: dist-sdist
           path: dist/
 
       - name: Install package
@@ -89,10 +98,11 @@ jobs:
           pyminify --version
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          show-progress: false
+          fetch-depth: 1
+          fetch-tags: 'true'
+          show-progress: 'false'
 
       - name: Build documentation
         run: |
@@ -108,39 +118,41 @@ jobs:
       matrix:
         python: ["2.7", "3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         package_type: [sdist, wheel]
-    container:
-      image: danielflook/python-minifier-build:python${{ matrix.python }}-2024-09-15
     steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: dist
-          path: dist/
-
-      - name: Install package
-        run: |
-          if [[ "${{ matrix.package_type }}" == "sdist" ]]; then
-            pip${{ matrix.python }} install dist/${{needs.package_python3.outputs.sdist}}
-          elif [[ "${{ matrix.python }}" == "2.7" ]]; then
-            pip${{ matrix.python }} install dist/${{needs.package_python2.outputs.wheel}}
-          else
-            pip${{ matrix.python }} install dist/${{needs.package_python3.outputs.wheel}}
-          fi
-          
-          pyminify --version
-
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          show-progress: false
+          fetch-depth: 1
+          fetch-tags: 'true'
+          show-progress: 'false'
 
-      - name: Test pyminify
-        run: |
-          set -x
-          cat setup.py | pyminify -
-          pyminify setup.py > /tmp/out.min.py
-          pyminify setup.py --output /tmp/out.min.py2
-          pyminify setup.py src test --in-place
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dist-*
+          path: dist/
+          merge-multiple: 'true'
+
+      - name: Test
+        uses: ./.github/actions/run-in-container
+        with:
+          image: danielflook/python-minifier-build:python${{ matrix.python }}-2024-09-15
+          run: |
+            if [[ "${{ matrix.package_type }}" == "sdist" ]]; then
+              pip${{ matrix.python }} install dist/${{needs.package_python3.outputs.sdist}}
+            elif [[ "${{ matrix.python }}" == "2.7" ]]; then
+              pip${{ matrix.python }} install dist/${{needs.package_python2.outputs.wheel}}
+            else
+              pip${{ matrix.python }} install dist/${{needs.package_python3.outputs.wheel}}
+            fi
+            
+            pyminify --version
+
+            set -x
+            cat setup.py | pyminify -
+            pyminify setup.py > /tmp/out.min.py
+            pyminify setup.py --output /tmp/out.min.py2
+            pyminify setup.py src test --in-place
 
   test_typing:
     runs-on: ubuntu-latest
@@ -151,10 +163,12 @@ jobs:
     container:
       image: danielflook/python-minifier-build:python3.13-2024-09-15
     steps:
-      - uses: actions/download-artifact@v3
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
         with:
-          name: dist
+          pattern: dist-*
           path: dist/
+          merge-multiple: 'true'
 
       - name: Install package
         run: |
@@ -165,10 +179,11 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          show-progress: false
+          fetch-depth: 1
+          fetch-tags: 'true'
+          show-progress: 'false'
 
       - name: Test typing
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,6 @@ name: Unit Test
 
 on: [push]
 
-env:
-   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
 
   test:
@@ -14,13 +11,13 @@ jobs:
       fail-fast: false
       matrix:
         python: ["python2.7", "python3.3", "python3.4", "python3.5", "python3.6", "python3.7", "python3.8", "python3.9", "python3.10", "python3.11", "python3.12", "python3.13", "pypy", "pypy3"]
-    container:
-      image: danielflook/python-minifier-build:${{ matrix.python }}-2024-09-15
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          fetch-tags: 'true'
+          show-progress: 'false'
 
       - name: Set version statically
         run: |
@@ -28,5 +25,8 @@ jobs:
           sed -i "s/setup_requires=.*/version='$VERSION',/; s/use_scm_version=.*//" setup.py
 
       - name: Run tests
-        run: |
-          tox -r -e $(echo "${{ matrix.python }}" | tr -d .)
+        uses: ./.github/actions/run-in-container
+        with:
+          image: danielflook/python-minifier-build:${{ matrix.python }}-2024-09-15
+          run: |
+            tox -r -e $(echo "${{ matrix.python }}" | tr -d .)

--- a/.github/workflows/test_corpus.yaml
+++ b/.github/workflows/test_corpus.yaml
@@ -34,9 +34,6 @@ on:
         required: false
         default: false
 
-env:
-   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   generate_results:
     name: Minify Corpus
@@ -46,98 +43,102 @@ jobs:
       matrix:
         python: ["2.7", "3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         ref: ["${{ inputs.ref }}", "${{ inputs.base-ref }}"]
-    container:
-      image: danielflook/python-minifier-build:python${{ matrix.python }}-2024-09-15
-      volumes:
-        - /corpus:/corpus
-        - /corpus-results:/corpus-results
     steps:
       - name: Clear workspace
         run: rm -rf "$GITHUB_WORKSPACE/*"
 
       - name: Checkout tests
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.0
         with:
+          fetch-depth: 1
+          fetch-tags: 'true'
+          show-progress: 'false'
           path: workflow
 
       - name: Checkout ref
-        uses: actions/checkout@v3
+        id: checkout-ref
+        uses: actions/checkout@v4.2.0
         with:
+          fetch-depth: 1
+          fetch-tags: 'true'
+          show-progress: 'false'
           ref: ${{ matrix.ref }}
           path: python-minifier
 
-      - name: Install ref
-        id: install
-        run: |
-          set -ex
-          (cd python-minifier && git log --pretty=format:'%H' -n 1) > sha.txt
-          cat sha.txt
-          VERSION=0.0.0
-          sed -i "s/setup_requires=.*/version='$VERSION',/; s/use_scm_version=.*//" python-minifier/setup.py
-          
-          if ! pip${{ matrix.python }} install python-minifier/ 2>stderr.log; then
-            echo stderr.log
-          
-            if grep -q -E 'require a different python version|requires a different Python' stderr.log; then
-              echo "${{ matrix.ref }} doesn't support Python ${{ matrix.python }}. Skipping."
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-            else
-              exit 1
-            fi
-          fi
-
       - name: Run tests
-        if: steps.install.outputs.skip != 'true'
-        run: |
-          if [[ "${{ matrix.python }}" == "3.3" || "${{ matrix.python }}" == "3.4" || "${{ matrix.python }}" == "3.5" ]]; then
-            # These versions randomise the hash seed, but don't preserve dict order
-            # This affects how names are assigned. Disable the hash randomisation for
-            # deterministic results.
-            export PYTHONHASHSEED=0
-          fi
-          
-          python${{matrix.python}} workflow/corpus_test/generate_results.py /corpus /corpus-results $(<sha.txt) ${{ inputs.regenerate-results }}
+        uses: ./.github/actions/run-in-container
+        with:
+          image: danielflook/python-minifier-build:python${{ matrix.python }}-2024-09-15
+          volumes: |
+            /corpus:/corpus
+            /corpus-results:/corpus-results
+          run: |
+            set -ex
+            VERSION=0.0.0
+            sed -i "s/setup_requires=.*/version='$VERSION',/; s/use_scm_version=.*//" python-minifier/setup.py
+            
+            if ! pip${{ matrix.python }} install python-minifier/ 2>stderr.log; then
+              echo stderr.log
+            
+              if grep -q -E 'require a different python version|requires a different Python' stderr.log; then
+                echo "${{ matrix.ref }} doesn't support Python ${{ matrix.python }}. Skipping."
+                exit 0
+              else
+                exit 1
+              fi
+            fi
+  
+            if [[ "${{ matrix.python }}" == "3.3" || "${{ matrix.python }}" == "3.4" || "${{ matrix.python }}" == "3.5" ]]; then
+              # These versions randomise the hash seed, but don't preserve dict order
+              # This affects how names are assigned. Disable the hash randomisation for
+              # deterministic results.
+              export PYTHONHASHSEED=0
+            fi
+            
+            python${{matrix.python}} workflow/corpus_test/generate_results.py /corpus /corpus-results ${{ steps.checkout-ref.outputs.commit }} ${{ inputs.regenerate-results }}
 
   generate_report:
     name: Generate Report
     needs: generate_results
     runs-on: self-hosted
-    container:
-      image: danielflook/python-minifier-build:python3.13-2024-09-15
-      volumes:
-        - /corpus-results:/corpus-results
     if: ${{ always() }}
     steps:
       - name: Clear workspace
         run: rm -rf "$GITHUB_WORKSPACE/*"
 
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Checkout workflow ref
+        uses: actions/checkout@v4.2.0
         with:
           path: workflow
+          fetch-depth: 1
+          fetch-tags: 'true'
+          show-progress: 'false'
 
       - name: Checkout ref
-        uses: actions/checkout@v3
+        id: ref
+        uses: actions/checkout@v4.2.0
         with:
           ref: ${{ inputs.ref }}
           path: python-minifier
-
-      - name: Get SHA
-        run: |
-          (cd python-minifier && git log --pretty=format:'%H' -n 1) > sha.txt       
-          cat sha.txt
+          fetch-depth: 1
+          fetch-tags: 'true'
+          show-progress: 'false'
 
       - name: Checkout base ref
-        uses: actions/checkout@v3
+        id: base-ref
+        uses: actions/checkout@v4.2.0
         with:
           ref: ${{ inputs.base-ref }}
           path: python-minifier-base
-
-      - name: Get base SHA
-        run: |
-          (cd python-minifier-base && git log --pretty=format:'%H' -n 1) > base-sha.txt
-          cat base-sha.txt
+          fetch-depth: 1
+          fetch-tags: 'true'
+          show-progress: 'false'
 
       - name: Generate Report
-        run: |
-          python3.13 workflow/corpus_test/generate_report.py /corpus-results ${{ inputs.ref }} $(<sha.txt) ${{ inputs.base-ref }} $(<base-sha.txt) >> $GITHUB_STEP_SUMMARY
+        uses: ./.github/actions/run-in-container
+        with:
+          image: danielflook/python-minifier-build:python3.13-2024-09-15
+          volumes: |
+            /corpus-results:/corpus-results
+          run: |
+            python3.13 workflow/corpus_test/generate_report.py /corpus-results ${{ inputs.ref }} ${{ steps.ref.outputs.commit }} ${{ inputs.base-ref }} ${{ steps.base-ref.outputs.commit }} >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/verify_release.yaml
+++ b/.github/workflows/verify_release.yaml
@@ -8,9 +8,6 @@ on:
         required: true
         type: string
 
-env:
-   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   test_package:
     runs-on: ubuntu-latest

--- a/.github/workflows/xtest.yaml
+++ b/.github/workflows/xtest.yaml
@@ -2,9 +2,6 @@ name: Regression Test
 
 on: [pull_request]
 
-env:
-   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
 
   test:
@@ -14,18 +11,16 @@ jobs:
       fail-fast: false
       matrix:
         python: ["python2.7", "python3.3", "python3.4", "python3.5", "python3.6", "python3.7", "python3.8", "python3.9", "python3.10", "python3.11", "python3.12", "python3.13", "pypy3"]
-    container:
-      image: danielflook/python-minifier-build:${{ matrix.python }}-2024-09-15
     steps:
-      - name: Cleanup
-        run: |
-          echo rm -vrf "$HOME/.*" "$HOME/*" "$GITHUB_WORKSPACE/.*" "$GITHUB_WORKSPACE/*"
-          rm -vrf "$HOME/.*" "$HOME/*" "$GITHUB_WORKSPACE/.*" "$GITHUB_WORKSPACE/*"
+      - name: Clear workspace
+        run: rm -rf "$GITHUB_WORKSPACE/*"
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          fetch-tags: 'true'
+          show-progress: 'false'
 
       - name: Set version statically
         run: |
@@ -33,17 +28,19 @@ jobs:
           sed -i "s/setup_requires=.*/version='$VERSION',/; s/use_scm_version=.*//" setup.py
 
       - name: Run tests
-        run: |
-
-          if [[ "${{ matrix.python }}" == "python3.4" ]]; then
-            (cd /usr/lib64/python3.4/test && python3.4 make_ssl_certs.py)
-          elif [[ "${{ matrix.python }}" == "python3.5" ]]; then
-            (cd /usr/lib64/python3.5/test && python3.5 make_ssl_certs.py)
-          elif [[ "${{ matrix.python }}" == "pypy3" ]]; then
-            (cd /usr/lib64/pypy3-7.0/lib-python/3/test && pypy3 make_ssl_certs.py)
-          fi
-          
-          tox -r -e $(echo "${{ matrix.python }}" | tr -d .) -- xtest
+        uses: ./.github/actions/run-in-container
+        with:
+          image: danielflook/python-minifier-build:${{ matrix.python }}-2024-09-15
+          run: |
+            if [[ "${{ matrix.python }}" == "python3.4" ]]; then
+              (cd /usr/lib64/python3.4/test && python3.4 make_ssl_certs.py)
+            elif [[ "${{ matrix.python }}" == "python3.5" ]]; then
+              (cd /usr/lib64/python3.5/test && python3.5 make_ssl_certs.py)
+            elif [[ "${{ matrix.python }}" == "pypy3" ]]; then
+              (cd /usr/lib64/pypy3-7.0/lib-python/3/test && pypy3 make_ssl_certs.py)
+            fi
+            
+            tox -r -e $(echo "${{ matrix.python }}" | tr -d .) -- xtest
 
   test-corpus:
     needs: test

--- a/corpus_test/generate_results.py
+++ b/corpus_test/generate_results.py
@@ -1,4 +1,5 @@
 import argparse
+import datetime
 import gzip
 import os
 import sys
@@ -97,19 +98,19 @@ def corpus_test(corpus_path, results_path, sha, regenerate_results):
     results_file_path = os.path.join(results_path, 'results_' + python_version + '_' + sha + '.csv')
 
     if os.path.isfile(results_file_path):
-        logging.info('Results file already exists: %s', results_file_path)
+        print('Results file already exists: %s' % results_file_path)
         if regenerate_results:
             os.remove(results_file_path)
 
     total_entries = len(corpus_entries)
-    logging.info('Testing python-minifier on %d entries' % total_entries)
+    print('Testing python-minifier on %d entries' % total_entries)
     tested_entries = 0
 
     start_time = time.time()
     next_checkpoint = time.time() + 60
 
     with ResultWriter(results_file_path) as result_writer:
-        logging.info('%d results already present' % len(result_writer))
+        print('%d results already present' % len(result_writer))
 
         for entry in corpus_entries:
             if entry in result_writer:
@@ -124,15 +125,15 @@ def corpus_test(corpus_path, results_path, sha, regenerate_results):
             sys.stdout.flush()
 
             if time.time() > next_checkpoint:
-                percent = len(result_writer) / total_entries * 100
+                percent = len(result_writer) / float(total_entries) * 100
                 time_per_entry = (time.time() - start_time) / tested_entries
                 entries_remaining = len(corpus_entries) - len(result_writer)
-                time_remaining = int(entries_remaining * time_per_entry)
-                logging.info('Tested %d/%d entries (%d%%) %s seconds remaining' % (len(result_writer), total_entries, percent, time_remaining))
+                time_remaining = datetime.timedelta(seconds=int(entries_remaining * time_per_entry))
+                print('Tested %d/%d entries (%d%%) estimated %s remaining' % (len(result_writer), total_entries, percent, time_remaining))
                 sys.stdout.flush()
                 next_checkpoint = time.time() + 60
 
-    logging.info('Finished')
+    print('Finished')
 
 def bool_parse(value):
     return value == 'true'


### PR DESCRIPTION
GitHub decided to use nodejs for their github actions, such as checkout/upload-artifact/download-artifact etc. This is problematic when running actions jobs inside containers, as node needs to get in there somehow. The actions runner rams a nodejs runtime into your containers, whether it works there or not.

GitHub are threatening to use a newer nodejs runtime, which certainly does NOT work in some of the older python containers.

To address this there is a new composite action called 'run-in-container', which tries to approximate the same behaviour as running jobs inside containers, but for a single step. This means that the GitHub provided actions in the job can now run outside the container.