### PR TITLE
Fix rename in place of first non-posonlyarg 

### DIFF
--- a/src/python_minifier/rename/util.py
+++ b/src/python_minifier/rename/util.py
@@ -85,7 +85,8 @@ def arg_rename_in_place(node):
         return True
 
     if isinstance(func.namespace, ast.ClassDef) and not isinstance(func, ast.Lambda):
-        if len(func.args.args) > 0 and node is func.args.args[0]:
+        all_args = (func.args.posonlyargs if hasattr(func.args, 'posonlyargs') else []) + func.args.args
+        if len(all_args) > 0 and node is all_args[0]:
             if len(func.decorator_list) == 0:
                 # rename 'self'
                 return True

--- a/test/test_rename_locals.py
+++ b/test/test_rename_locals.py
@@ -164,6 +164,85 @@ class TestClass():
     actual_ast = rename_locals(source)
     assert_code(expected_ast, actual_ast)
 
+
+def test_rename_posargs_in_place():
+    if sys.version_info < (3, 8):
+        pytest.skip('No posonlyargs in python < 3.8')
+
+    source = '''
+def test(arg, /, arg2): return arg, arg2
+
+class TestClass():
+    def mymethod(self, arg, /, arg2): return arg, arg2
+
+    @classmethod
+    def mymethod(cls, arg, /, arg2): return arg, arg2
+'''
+    expected = '''
+def test(A,/,arg2):return A,arg2
+class TestClass:
+	def mymethod(B,A,/,arg2):return A,arg2
+	@classmethod
+	def mymethod(B,A,/,arg2):return A,arg2
+'''
+
+    expected_ast = ast.parse(expected)
+    actual_ast = rename_locals(source)
+    assert_code(expected_ast, actual_ast)
+
+
+def test_rename_kwargonlyargs_in_place():
+    if sys.version_info < (3, 0):
+        pytest.skip('No kwonlyargs in python < 3.0')
+
+    source = '''
+def test(arg, arg2, *, arg3): return arg, arg2, arg3
+
+class TestClass():
+    def mymethod(self, arg, arg2, *, arg3): return arg, arg2, arg3
+
+    @classmethod
+    def mymethod(cls, arg, arg2, *, arg3): return arg, arg2, arg3
+'''
+    expected = '''
+def test(arg,arg2,*,arg3):return arg,arg2,arg3
+class TestClass:
+	def mymethod(A,arg,arg2,*,arg3):return arg,arg2,arg3
+	@classmethod
+	def mymethod(A,arg,arg2,*,arg3):return arg,arg2,arg3
+'''
+
+    expected_ast = ast.parse(expected)
+    actual_ast = rename_locals(source)
+    assert_code(expected_ast, actual_ast)
+
+
+def test_rename_posargs_kwargonlyargs_in_place():
+    if sys.version_info < (3, 8):
+        pytest.skip('No posonlyargs in python < 3.8')
+
+    source = '''
+def test(arg, /, arg2, *, arg3): return arg, arg2, arg3
+
+class TestClass():
+    def mymethod(self, arg, /, arg2, *, arg3): return arg, arg2, arg3
+
+    @classmethod
+    def mymethod(cls, arg, /, arg2, *, arg3): return arg, arg2, arg3
+'''
+    expected = '''
+def test(A,/,arg2,*,arg3):return A,arg2,arg3
+class TestClass:
+	def mymethod(B,A,/,arg2,*,arg3):return A,arg2,arg3
+	@classmethod
+	def mymethod(B,A,/,arg2,*,arg3):return A,arg2,arg3
+'''
+
+    expected_ast = ast.parse(expected)
+    actual_ast = rename_locals(source)
+    assert_code(expected_ast, actual_ast)
+
+
 def test_no_rename_long_arg():
     source = '''
 def f(this_is_my_long_argument_name):


### PR DESCRIPTION
The first non-posonly arg in a method definition was mistakenly thought to be 'self' and eligible for renaming in place.
This change accounts for any posonly args when considering the 'first' argument to a method.

e.g my_arg will no longer be renamed in place:
```python
class MyClass
  def my_method(self, /, my_arg): pass
```