### PR TITLE
Fix: Ensure ModulePrinter respects the indent_char argument

### DIFF
--- a/src/python_minifier/module_printer.py
+++ b/src/python_minifier/module_printer.py
@@ -13,7 +13,7 @@ class ModulePrinter(ExpressionPrinter):
 
     def __init__(self, indent_char='\t'):
         super(ModulePrinter, self).__init__()
-        self.indent_char = indent_char
+        self.printer.indent_char = indent_char
 
     def __call__(self, module):
         """
@@ -30,13 +30,13 @@ class ModulePrinter(ExpressionPrinter):
         self.visit_Module(module)
         # On Python 2.7, preserve unicode strings to avoid encoding issues
         code = unicode(self.printer) if sys.version_info[0] < 3 else str(self.printer)
-        return code.rstrip('\n' + self.indent_char + ';')
+        return code.rstrip('\n' + self.printer.indent_char + ';')
 
     @property
     def code(self):
         # On Python 2.7, preserve unicode strings to avoid encoding issues
         code = unicode(self.printer) if sys.version_info[0] < 3 else str(self.printer)
-        return code.rstrip('\n' + self.indent_char + ';')
+        return code.rstrip('\n' + self.printer.indent_char + ';')
 
     # region Simple Statements
 

--- a/src/python_minifier/token_printer.py
+++ b/src/python_minifier/token_printer.py
@@ -99,6 +99,7 @@ class TokenPrinter(object):
         self.indent = 0
         self.unicode_literals = False
         self.previous_token = TokenTypes.NoToken
+        self.indent_char = '\t'
 
     def __str__(self):
         """Return the output code."""
@@ -287,9 +288,9 @@ class TokenPrinter(object):
         if self._code == '':
             return
 
-        self._code = self._code.rstrip('\n\t;')
+        self._code = self._code.rstrip('\n;' + self.indent_char)
         self._code += '\n'
-        self._code += '\t' * self.indent
+        self._code += self.indent_char * self.indent
 
         self.previous_token = TokenTypes.NewLine
 


### PR DESCRIPTION
This PR fixes a bug in `ModulePrinter` where the `indent_char` argument specified during initialization was being ignored.

Currently, the printer defaults to using a tab character (`\t`) for indentation, regardless of the character provided to the `indent_char` argument. This change ensures that the specified `indent_char` is correctly used when generating the output source code.

### Verification

The following example demonstrates the corrected behavior.

```python
import ast
from python_minifier.module_printer import ModulePrinter

module = ast.parse("def f():\n    while True:\n        print('hello')")

# Initialize the printer with a single space as the indent_char
printer = ModulePrinter(indent_char=" ")
result = printer(module)

# The expected output should use a space for indentation
expected = "def f():\n while True:print('hello')"

# Before this fix, the result was:
# "def f():\n\twhile True:print('hello')"

assert result == expected
```